### PR TITLE
Android RSA key size configurable through preference

### DIFF
--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -28,7 +28,7 @@ public class RSA {
 		return cipher.doFinal(encrypted);
 	}
 
-	public static void createKeyPair(Context ctx, String alias) throws Exception {
+	public static void createKeyPair(Context ctx, String alias, int keySize) throws Exception {
 		Calendar notBefore = Calendar.getInstance();
 		Calendar notAfter = Calendar.getInstance();
 		notAfter.add(Calendar.YEAR, 100);
@@ -40,7 +40,7 @@ public class RSA {
 			.setStartDate(notBefore.getTime())
 			.setEndDate(notAfter.getTime())
 			.setEncryptionRequired()
-			.setKeySize(2048)
+			.setKeySize(keySize)
 			.setKeyType("RSA")
 			.build();
 		KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance("RSA", KEYSTORE_PROVIDER);

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -6,6 +6,8 @@ import android.util.Base64;
 import android.content.Context;
 import android.content.Intent;
 
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaPlugin;
@@ -16,10 +18,20 @@ import javax.crypto.Cipher;
 public class SecureStorage extends CordovaPlugin {
     private static final String TAG = "SecureStorage";
 
-    private String ALIAS;
+    private static final String PREFERENCE_RSA_KEY_SIZE = "RSAKeySize";
+    private static final int DEFAULT_RSA_KEY_SIZE =  2048;
 
+    private String ALIAS;
+    private int RSA_keySize;
     private volatile CallbackContext initContext;
     private volatile boolean initContextRunning = false;
+
+    @Override
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        RSA_keySize  = preferences.getInteger(PREFERENCE_RSA_KEY_SIZE, DEFAULT_RSA_KEY_SIZE);
+        Log.v(TAG, "RSA key size : " + RSA_keySize);
+    }
 
     @Override
     public void onResume(boolean multitasking) {
@@ -29,7 +41,7 @@ public class SecureStorage extends CordovaPlugin {
                     initContextRunning = true;
                     try {
                         if (!RSA.isEntryAvailable(ALIAS)) {
-                            RSA.createKeyPair(getContext(), ALIAS);
+                            RSA.createKeyPair(getContext(), ALIAS, RSA_keySize);
                         }
                         initContext.success();
                     } catch (Exception e) {


### PR DESCRIPTION
One can now specify the size of the RSA key used by the android plugin by adding
preference name="RSAKeySize" value="1024"
to config.xml
The default value is still 2048.