### PR TITLE
Added ability to configure Keychain Item Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ ss.remove(
 #### iOS
 On iOS secrets are stored directly in the KeyChain through the [SSKeychain](https://github.com/soffes/sskeychain) library.
 
+##### Configuration
+You could configure the accessibility of the KeychainItems by setting the `KeychainAccessibility` preference in the `config.xml` to one of the following strings:
+ * AfterFirstUnlock
+ * AfterFirstUnlockThisDeviceOnly
+ * WhenUnlocked
+ * WhenUnlockedThisDeviceOnly
+ * Always
+ * AlwaysThisDeviceOnly
+ * WhenPasscodeSetThisDeviceOnly
+
+For reference what these settings mean, see [Keychain Item Accessibility Constants](https://developer.apple.com/library/ios/documentation/Security/Reference/keychainservices/#//apple_ref/doc/constant_group/Keychain_Item_Accessibility_Constants).
+
 #### Android
 On Android there does not exist an equivalent of the iOS KeyChain. The ``SecureStorage`` API is implemented as follows:
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,10 +36,10 @@
         <source-file src="src/ios/SecureStorage.m" />
         <header-file src="src/ios/SecureStorage.h" />
 
-        <source-file src="src/ios/SSkeychain/SSKeychain.m" />
-        <header-file src="src/ios/SSkeychain/SSKeychain.h" />
-        <source-file src="src/ios/SSkeychain/SSKeychainQuery.m" />
-        <header-file src="src/ios/SSkeychain/SSKeychainQuery.h" />
+        <source-file src="src/ios/SSKeychain/SSKeychain.m" />
+        <header-file src="src/ios/SSKeychain/SSKeychain.h" />
+        <source-file src="src/ios/SSKeychain/SSKeychainQuery.m" />
+        <header-file src="src/ios/SSKeychain/SSKeychainQuery.h" />
 
         <framework src="Security.framework" />
 

--- a/src/ios/SSKeychain/SSKeychain.m
+++ b/src/ios/SSKeychain/SSKeychain.m
@@ -18,7 +18,7 @@ NSString *const kSSKeychainLastModifiedKey = @"mdat";
 NSString *const kSSKeychainWhereKey = @"svce";
 
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	static CFTypeRef SSKeychainAccessibilityType = NULL;
+	static CFTypeRef SSKeychainAccessibilityType = kSecAttrAccessibleAfterFirstUnlock;
 #endif
 
 @implementation SSKeychain

--- a/src/ios/SSKeychain/SSKeychain.m
+++ b/src/ios/SSKeychain/SSKeychain.m
@@ -18,7 +18,7 @@ NSString *const kSSKeychainLastModifiedKey = @"mdat";
 NSString *const kSSKeychainWhereKey = @"svce";
 
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	static CFTypeRef SSKeychainAccessibilityType = kSecAttrAccessibleAfterFirstUnlock;
+	static CFTypeRef SSKeychainAccessibilityType = NULL;
 #endif
 
 @implementation SSKeychain

--- a/src/ios/SecureStorage.h
+++ b/src/ios/SecureStorage.h
@@ -7,6 +7,6 @@
 - (void)remove:(CDVInvokedUrlCommand*)command;
 
 @property (nonatomic, copy) NSString *callbackId;
+@property (nonatomic, copy) id keychainAccesssibilityMapping;
 
 @end
-

--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -14,13 +14,13 @@
     NSString *service = [command argumentAtIndex:0];
     NSString *key = [command argumentAtIndex:1];
     NSError *error;
-    
+
     self.callbackId = command.callbackId;
-    
+
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = service;
     query.account = key;
-    
+
     if ([query fetch:&error]) {
         [self successWithMessage: query.password];
     } else {
@@ -34,9 +34,9 @@
     NSString *key = [command argumentAtIndex:1];
     NSString *value = [command argumentAtIndex:2];
     NSError *error;
-    
+
     self.callbackId = command.callbackId;
-    
+
     if (self.keychainAccesssibilityMapping == nil) {
         self.keychainAccesssibilityMapping = [NSDictionary dictionaryWithObjectsAndKeys:
                                               (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly), @"afterfirstunlockthisdeviceonly",
@@ -48,20 +48,20 @@
                                               (__bridge id)(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly), @"whenpasscodesetthisdeviceonly",
                                               nil];
     }
-    
+
     NSString* keychainAccessibility = [[self.commandDelegate.settings objectForKey:[@"KeychainAccessibility" lowercaseString]] lowercaseString];
-    
+
     if ([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)] != nil) {
         CFTypeRef accessability = (__bridge CFTypeRef)([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)]);
         [SSKeychain setAccessibilityType:accessability];
     }
-    
+
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
-    
+
     query.service = service;
     query.account = key;
     query.password = value;
-    
+
     if ([query save:&error]) {
         [self successWithMessage: key];
     } else {
@@ -74,13 +74,13 @@
     NSString *service = [command argumentAtIndex:0];
     NSString *key = [command argumentAtIndex:1];
     NSError *error;
-    
+
     self.callbackId = command.callbackId;
-    
+
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = service;
     query.account = key;
-    
+
     if ([query deleteItem:&error]) {
         [self successWithMessage: key];
     } else {
@@ -101,7 +101,7 @@
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
-    
+
     [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
 }
 

--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <Security/Security.h>
 #import "SecureStorage.h"
 #import <Cordova/CDV.h>
 #import "SSKeychain.h"
@@ -35,7 +36,10 @@
 
     self.callbackId = command.callbackId;
 
+    [SSKeychain setAccessibilityType: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly];
+    
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    
     query.service = service;
     query.account = key;
     query.password = value;


### PR DESCRIPTION
Added the ability to configure the keychain item's accessibility in cordovas `config.xml` according to the [keychain documentation](https://developer.apple.com/library/ios/documentation/Security/Reference/keychainservices/#//apple_ref/doc/constant_group/Keychain_Item_Accessibility_Constants) using the `setAccessibilityType` method already provided by SSKeychain.

