### PR TITLE
Run commands in threads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.2.2 - unreleased
+------------------
+
+- Execute iOS commands in separate threads instead of the main thread.
+  [goshakkk / hellyeahllc]
+
 2.2.1 - 2016-02-09
 ------------------
 

--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -13,19 +13,21 @@
 {
     NSString *service = [command argumentAtIndex:0];
     NSString *key = [command argumentAtIndex:1];
-    NSError *error;
+    [self.commandDelegate runInBackground:^{
+        NSError *error;
 
-    self.callbackId = command.callbackId;
+        self.callbackId = command.callbackId;
 
-    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
-    query.service = service;
-    query.account = key;
+        SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+        query.service = service;
+        query.account = key;
 
-    if ([query fetch:&error]) {
-        [self successWithMessage: query.password];
-    } else {
-        [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
-    }
+        if ([query fetch:&error]) {
+            [self successWithMessage: query.password];
+        } else {
+            [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
+        }
+    }];
 }
 
 - (void)set:(CDVInvokedUrlCommand*)command
@@ -33,72 +35,76 @@
     NSString *service = [command argumentAtIndex:0];
     NSString *key = [command argumentAtIndex:1];
     NSString *value = [command argumentAtIndex:2];
-    NSError *error;
+    [self.commandDelegate runInBackground:^{
+        NSError *error;
 
-    self.callbackId = command.callbackId;
+        self.callbackId = command.callbackId;
 
-    if (self.keychainAccesssibilityMapping == nil) {
+        if (self.keychainAccesssibilityMapping == nil) {
 
-		if( [[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0 ){
-        	self.keychainAccesssibilityMapping = [NSDictionary dictionaryWithObjectsAndKeys:
-                                              (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly), @"afterfirstunlockthisdeviceonly",
-                                              (__bridge id)(kSecAttrAccessibleAfterFirstUnlock), @"afterfirstunlock",
-                                              (__bridge id)(kSecAttrAccessibleWhenUnlocked), @"whenunlocked",
-                                              (__bridge id)(kSecAttrAccessibleWhenUnlockedThisDeviceOnly), @"whenunlockedthisdeviceonly",
-                                              (__bridge id)(kSecAttrAccessibleAlways), @"always",
-                                              (__bridge id)(kSecAttrAccessibleAlwaysThisDeviceOnly), @"alwaysthisdeviceonly",
-                                              (__bridge id)(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly), @"whenpasscodesetthisdeviceonly",
-                                              nil];
-		}
-		else{
-        	self.keychainAccesssibilityMapping = [NSDictionary dictionaryWithObjectsAndKeys:
-                                              (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly), @"afterfirstunlockthisdeviceonly",
-                                              (__bridge id)(kSecAttrAccessibleAfterFirstUnlock), @"afterfirstunlock",
-                                              (__bridge id)(kSecAttrAccessibleWhenUnlocked), @"whenunlocked",
-                                              (__bridge id)(kSecAttrAccessibleWhenUnlockedThisDeviceOnly), @"whenunlockedthisdeviceonly",
-                                              (__bridge id)(kSecAttrAccessibleAlways), @"always",
-                                              (__bridge id)(kSecAttrAccessibleAlwaysThisDeviceOnly), @"alwaysthisdeviceonly",
-                                              nil];
-		}
-    }
+        if( [[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0 ){
+              self.keychainAccesssibilityMapping = [NSDictionary dictionaryWithObjectsAndKeys:
+                                                  (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly), @"afterfirstunlockthisdeviceonly",
+                                                  (__bridge id)(kSecAttrAccessibleAfterFirstUnlock), @"afterfirstunlock",
+                                                  (__bridge id)(kSecAttrAccessibleWhenUnlocked), @"whenunlocked",
+                                                  (__bridge id)(kSecAttrAccessibleWhenUnlockedThisDeviceOnly), @"whenunlockedthisdeviceonly",
+                                                  (__bridge id)(kSecAttrAccessibleAlways), @"always",
+                                                  (__bridge id)(kSecAttrAccessibleAlwaysThisDeviceOnly), @"alwaysthisdeviceonly",
+                                                  (__bridge id)(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly), @"whenpasscodesetthisdeviceonly",
+                                                  nil];
+        }
+        else{
+              self.keychainAccesssibilityMapping = [NSDictionary dictionaryWithObjectsAndKeys:
+                                                  (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly), @"afterfirstunlockthisdeviceonly",
+                                                  (__bridge id)(kSecAttrAccessibleAfterFirstUnlock), @"afterfirstunlock",
+                                                  (__bridge id)(kSecAttrAccessibleWhenUnlocked), @"whenunlocked",
+                                                  (__bridge id)(kSecAttrAccessibleWhenUnlockedThisDeviceOnly), @"whenunlockedthisdeviceonly",
+                                                  (__bridge id)(kSecAttrAccessibleAlways), @"always",
+                                                  (__bridge id)(kSecAttrAccessibleAlwaysThisDeviceOnly), @"alwaysthisdeviceonly",
+                                                  nil];
+        }
+        }
 
-    NSString* keychainAccessibility = [[self.commandDelegate.settings objectForKey:[@"KeychainAccessibility" lowercaseString]] lowercaseString];
+        NSString* keychainAccessibility = [[self.commandDelegate.settings objectForKey:[@"KeychainAccessibility" lowercaseString]] lowercaseString];
 
-    if ([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)] != nil) {
-        CFTypeRef accessibility = (__bridge CFTypeRef)([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)]);
-        [SSKeychain setAccessibilityType:accessibility];
-    }
+        if ([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)] != nil) {
+            CFTypeRef accessibility = (__bridge CFTypeRef)([self.keychainAccesssibilityMapping objectForKey:(keychainAccessibility)]);
+            [SSKeychain setAccessibilityType:accessibility];
+        }
 
-    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+        SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
 
-    query.service = service;
-    query.account = key;
-    query.password = value;
+        query.service = service;
+        query.account = key;
+        query.password = value;
 
-    if ([query save:&error]) {
-        [self successWithMessage: key];
-    } else {
-        [self failWithMessage: @"Failure in SecureStorage.set()" withError: error];
-    }
+        if ([query save:&error]) {
+            [self successWithMessage: key];
+        } else {
+            [self failWithMessage: @"Failure in SecureStorage.set()" withError: error];
+        }
+    }];
 }
 
 - (void)remove:(CDVInvokedUrlCommand*)command
 {
     NSString *service = [command argumentAtIndex:0];
     NSString *key = [command argumentAtIndex:1];
-    NSError *error;
+    [self.commandDelegate runInBackground:^{
+        NSError *error;
 
-    self.callbackId = command.callbackId;
+        self.callbackId = command.callbackId;
 
-    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
-    query.service = service;
-    query.account = key;
+        SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+        query.service = service;
+        query.account = key;
 
-    if ([query deleteItem:&error]) {
-        [self successWithMessage: key];
-    } else {
-        [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
-    }
+        if ([query deleteItem:&error]) {
+            [self successWithMessage: key];
+        } else {
+            [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
+        }
+    }];
 }
 
 -(void)successWithMessage:(NSString *)message


### PR DESCRIPTION
Seems like executing commands in separate threads is what's usually done. Also this removes an annoying runtime warning:

```
2016-05-02 22:02:22.979 Crossover[2563:1224554] THREAD WARNING: ['SecureStorage'] took '11.879150' ms. Plugin should use a background thread.
```