### PR TITLE
Remove `require('crypto')` in sjcl_ss.js for Cordova --browserify

### DIFF
--- a/www/sjcl_ss.js
+++ b/www/sjcl_ss.js
@@ -1980,12 +1980,8 @@ sjcl.random = new sjcl.prng(6);
 (function(){
   // function for getting nodejs crypto module. catches and ignores errors.
   function getCryptoModule() {
-    try {
-      return require('crypto');
-    }
-    catch (e) {
-      return null;
-    }
+    // return require('crypto'); // it will cause browserify package a huge node-crypto polyfill into the cordova.js bundle
+    return null;
   }
 
   try {


### PR DESCRIPTION
`cordova build --browserify` will pack all js files of plugins into the cordova.js file.
But during browerify, since the sjcl_ss.js has `require('crypto')`, which result in a unnecessary huge [crypto-browserify](https://github.com/crypto-browserify/crypto-browserify) polyfill will be added into the cordova.js bundle.
Since we already decided to remove this file sooner or later, I think it is fine to just modify it a little, to make it works better for the --browserify flag