### PR TITLE
Always pass Error instance to failure callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2,6 +2,11 @@ exports.defineAutoTests = function() {
     var ss, handlers;
     var SERVICE = 'testing';
 
+    // Fixes Object [object Array] has no method 'includes' on Android 4.4 emulator
+    Array.prototype.includes = Array.prototype.includes || function(value) {
+        return this.indexOf(value) >= 0;
+    }
+
     describe('cordova-plugin-secure-storage', function () {
 
         beforeEach(function () {
@@ -95,7 +100,7 @@ exports.defineAutoTests = function() {
             var results = [];
             spyOn(handlers, 'successHandler').and.callFake(function (res) {
                 results.push(res);
-                expect(res === 'foo' || res === 'bar');
+                expect(res === 'foo' || res === 'bar').toBe(true);
                 if (results.includes('foo') && results.includes('bar')) {
                     done();
                 }


### PR DESCRIPTION
Previously the failure callback for the get() method may receive either an Error object or a string message.  By Cordova convention a failure callback should always receive an instance of JavaScript error. This PR makes the logic consistent and always pass an instance of JavaScript error following Cordova best practice.

This PR also fixes minor issues in unit tests so all tests now pass:

![image](https://cloud.githubusercontent.com/assets/981580/16391746/327246c6-3cb1-11e6-8c9c-818a8c145f2a.png)


