### PR TITLE
Adds Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# SecureStorage plugin for iOS & Android
+# SecureStorage plugin for Apache Cordova
 
 ## Introduction
 
-This plugin is for use with [Cordova](http://incubator.apache.org/cordova/) and allows your application to securely store secrets on iOS & Android phones.
+This plugin is for use with [Cordova](http://incubator.apache.org/cordova/) and allows your application to securely store secrets on  iOS & Android phones and Windows devices.
+
+### Supported platforms
+
+  * Android
+  * iOS
+  * Windows (Windows 8.x/Store, Windows 10/UWP and Windows Phone 8.1+)
 
 ### Contents
 
@@ -118,6 +124,13 @@ On Android there does not exist an equivalent of the iOS KeyChain. The ``SecureS
 The inverse process is followed on ``get``.
 
 Native AES is used when available, otherwise encryption is provided by the [sjcl](https://github.com/bitwiseshiftleft/sjcl) library.
+
+#### Windows
+Windows implementation is based on [PasswordVault](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.passwordvault.aspx) object from the [Windows.Security.Credentials](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.aspx) namespace.
+The contents of the locker are specific to the app so different apps and services don't have access to credentials associated with other apps or services.
+
+**Limitations:** you can only store up to ten credentials per app. If you try to store more than ten credentials, you will
+encounter an error. Read [documentation](https://msdn.microsoft.com/en-us/library/windows/apps/hh701231.aspx) for more details.
 
 #### Browser
 The browser platform is supported as a mock only. Key/values are stored unencrypted in localStorage.

--- a/plugin.xml
+++ b/plugin.xml
@@ -65,4 +65,10 @@
         </config-file>
     </platform>
 
+    <platform name="windows">
+        <js-module src="src/windows/SecureStorage.js" name="SecureStorageWindowsImpl">
+            <runs />
+        </js-module>
+    </platform>
+
 </plugin>

--- a/src/windows/SecureStorage.js
+++ b/src/windows/SecureStorage.js
@@ -1,0 +1,53 @@
+var SecureStorageProxy = {
+    get: function (win, fail, args) {
+        try {
+            var service = args[0];
+            var key = args[1];
+
+            var vault = new Windows.Security.Credentials.PasswordVault();
+            var passwordCredential = vault.retrieve(service, key);
+
+            win(passwordCredential.password);
+        } catch (e) {
+            fail('Failure in SecureStorage.get() - ' + e.message);
+        }
+    },
+    set: function (win, fail, args) {
+        try {
+            var service = args[0];
+            var key = args[1];
+            var value = args[2];
+
+            // Remarks: you can only store up to ten credentials per app in the Credential Locker.
+            // If you try to store more than ten credentials, you will encounter an Exception.
+            // https://msdn.microsoft.com/en-us/library/windows/apps/hh701231.aspx
+
+            var vault = new Windows.Security.Credentials.PasswordVault();
+            vault.add(new Windows.Security.Credentials.PasswordCredential(
+                service, key, value));
+
+            win(key);
+        } catch (e) {
+            fail('Failure in SecureStorage.set() - ' + e.message);
+        }
+    },
+    remove: function (win, fail, args) {
+        try {
+            var service = args[0];
+            var key = args[1];
+
+            var vault = new Windows.Security.Credentials.PasswordVault();
+            var passwordCredential = vault.retrieve(service, key);
+
+            if (passwordCredential) {
+                vault.remove(passwordCredential);
+            }
+
+            win(key);
+        } catch (e) {
+            fail('Failure in SecureStorage.remove() - ' + e.message);
+        }
+    },
+};
+
+require("cordova/exec/proxy").add("SecureStorage", SecureStorageProxy);

--- a/www/securestorage.js
+++ b/www/securestorage.js
@@ -1,4 +1,4 @@
-var SecureStorage, SecureStorageiOS, SecureStorageAndroid, SecureStorageBrowser;
+var SecureStorage, SecureStorageiOS, SecureStorageAndroid, SecureStorageWindows, SecureStorageBrowser;
 var sjcl_ss = cordova.require('cordova-plugin-secure-storage.sjcl_ss');
 var _AES_PARAM = {
     ks: 256,
@@ -68,6 +68,10 @@ SecureStorageiOS.prototype = {
         }
     }
 };
+
+// SecureStorage for Windows web interface and proxy parameters are the same as on iOS
+// so we don't create own definition for Windows and simply re-use iOS
+SecureStorageWindows = SecureStorageiOS;
 
 SecureStorageAndroid = function (success, error, service, options) {
     var self = this;
@@ -328,6 +332,9 @@ case 'ios':
     break;
 case 'android':
     SecureStorage = SecureStorageAndroid;
+    break;
+case 'windows':
+    SecureStorage = SecureStorageWindows;
     break;
 case 'browser':
     SecureStorage = SecureStorageBrowser;


### PR DESCRIPTION
Adds Windows implementation based on [PasswordVault](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.passwordvault.aspx) object from the [Windows.Security.Credentials](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.aspx) namespace (`key` is mapped to `username` and `value` to `password`). This is what MSDN recommends: [How to store user credentials](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh465069(v=win.10).aspx).

> The contents of the locker are specific to the app or service. Apps and services don't have access to credentials associated with other apps or services.

Unit tests pass.
![image](https://cloud.githubusercontent.com/assets/981580/16496046/ad40422e-3ef8-11e6-8b5d-34613beab9f0.png)
