### PR TITLE
Add setting failOnDeviceInsecure to prevent OS warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The inverse process is followed on ``get``.
 
 Native AES is used when available, otherwise encryption is provided by the [sjcl](https://github.com/bitwiseshiftleft/sjcl) library.
 
+##### Users must have a PIN code set
+
+The plugin will only work correctly if the user has created a PIN or password for the lock screen. When the plugin initializes the operating system will display a popup telling the user to set a pin, you can prevent the popup by passing the below additional option.
+
+```js
+new window.cordova.plugins.SecureStorage(
+	success, error, key, {preventNoPinDialog: true}
+);
+```
+
 #### Windows
 Windows implementation is based on [PasswordVault](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.passwordvault.aspx) object from the [Windows.Security.Credentials](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.aspx) namespace.
 The contents of the locker are specific to the app so different apps and services don't have access to credentials associated with other apps or services.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The plugin will only work correctly if the user has created a PIN or password fo
 
 ```js
 new window.cordova.plugins.SecureStorage(
-	success, error, key, {preventNoPinDialog: true}
+	success, error, key, {failOnDeviceInsecure: true}
 );
 ```
 

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -45,9 +45,9 @@ public class SecureStorage extends CordovaPlugin {
         }
     }
 
-    private boolean isPinSet() {
+    private boolean isDeviceSecure() {
         KeyguardManager keyguardManager = (KeyguardManager)(getContext().getSystemService(Context.KEYGUARD_SERVICE));
-        return keyguardManager.isKeyguardSecure();
+        return keyguardManager.isDeviceSecure();
     }
 
     @Override
@@ -56,10 +56,12 @@ public class SecureStorage extends CordovaPlugin {
             // 0 is falsy in js while 1 is truthy
             SUPPORTS_NATIVE_AES = Build.VERSION.SDK_INT >= 21 ? 1 : 0;
             ALIAS = getContext().getPackageName() + "." + args.getString(0);
-            boolean preventPinDialog = args.getBoolean(1);
+            boolean failOnDeviceInsecure = args.getBoolean(1);
 
-            if (preventPinDialog && !isPinSet()) {
-                callbackContext.success(SUPPORTS_NATIVE_AES);
+            if (failOnDeviceInsecure && !isDeviceSecure()) {
+                String message = "Device is not secure and plugin configured to failOnDeviceInsecure";
+                Log.e(TAG, message);
+                callbackContext.error(message);
             } else if (!RSA.isEntryAvailable(ALIAS)) {
                 initContext = callbackContext;
                 unlockCredentials();

--- a/www/securestorage.js
+++ b/www/securestorage.js
@@ -121,7 +121,7 @@ SecureStorageAndroid = function (success, error, service, options) {
             },
             error,
             'init',
-            [this.service]
+            [this.service, options.preventNoPinDialog]
         );
     } catch (e) {
         error(e);
@@ -131,7 +131,8 @@ SecureStorageAndroid = function (success, error, service, options) {
 
 SecureStorageAndroid.prototype = {
     options: {
-        native: true
+        native: true,
+        preventNoPinDialog: false
     },
 
     get: function (success, error, key) {

--- a/www/securestorage.js
+++ b/www/securestorage.js
@@ -121,7 +121,7 @@ SecureStorageAndroid = function (success, error, service, options) {
             },
             error,
             'init',
-            [this.service, options.preventNoPinDialog]
+            [this.service, options.failOnDeviceInsecure]
         );
     } catch (e) {
         error(e);
@@ -132,7 +132,7 @@ SecureStorageAndroid = function (success, error, service, options) {
 SecureStorageAndroid.prototype = {
     options: {
         native: true,
-        preventNoPinDialog: false
+        failOnDeviceInsecure: false
     },
 
     get: function (success, error, key) {


### PR DESCRIPTION
I borrowed some of the language from pr #31.

I'm not sure what to make of `callbackContext.success(SUPPORTS_NATIVE_AES);` in the init action. Maybe I should call error instead of success?