### PR TITLE
Gracefully fail on Android <4.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.6.4 - 2017-03-29
+------------------
+
+- Graceful handling of unsupported Android versions (4.3 and below).
+
 2.6.3 - 2016-11-21
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.3">
+    version="2.6.4">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -38,7 +38,7 @@ public class SecureStorage extends CordovaPlugin {
             secureDeviceContext = null;
         }
 
-        if (initContext != null && !initContextRunning) {
+        if (isAndroidVersionSupported(secureDeviceContext) && initContext != null && !initContextRunning) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     initContextRunning = true;
@@ -72,6 +72,9 @@ public class SecureStorage extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+        if(!isAndroidVersionSupported(callbackContext)){
+            return false;
+        }
         if ("init".equals(action)) {
             // 0 is falsy in js while 1 is truthy
             SUPPORTS_NATIVE_AES = Build.VERSION.SDK_INT >= 21 ? 1 : 0;
@@ -228,5 +231,18 @@ public class SecureStorage extends CordovaPlugin {
 
     private void startActivity(Intent intent){
         cordova.getActivity().startActivity(intent);
+    }
+
+    private boolean isAndroidVersionSupported(CallbackContext context){
+        boolean supported = true;
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT){
+            String errMsg = "API 19 (Android 4.4 KitKat) is required. This device is running API " + android.os.Build.VERSION.SDK_INT;
+            Log.w(TAG, errMsg);
+            if(context != null){
+                context.error(errMsg);
+            }
+            supported = false;
+        }
+        return supported;
     }
 }

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -18,4 +18,8 @@
     <js-module src="tests.js" name="tests">
     </js-module>
 
+    <platform name="android">
+        <dependency id="cordova-plugin-device" version="*" />
+    </platform>
+
 </plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,6 +3,33 @@ var SERVICE = 'testing';
 exports.defineAutoTests = function() {
     var ss, handlers;
 
+    if(cordova.platformId === 'android' && parseFloat(device.version) <= 4.3){
+        describe('cordova-plugin-secure-storage-android-unsupported', function () {
+            beforeEach(function () {
+                handlers = {
+                    successHandler: function () {},
+                    errorHandler: function () {}
+                };
+            });
+
+            it('should call the error handler when attempting to use the plugin on Android 4.3 or below', function (done) {
+                spyOn(handlers, 'errorHandler').and.callFake(function (res) {
+                    expect(res).toEqual(jasmine.any(Error));
+                    expect(handlers.successHandler).not.toHaveBeenCalled();
+                    done();
+                });
+                spyOn(handlers, 'successHandler');
+
+                ss = new cordova.plugins.SecureStorage(function () {
+                    ss.set(function () {
+                        ss.get(handlers.successHandler, handlers.errorHandler, 'foo');
+                    }, function () {}, 'foo', 'foo');
+                }, handlers.errorHandler, SERVICE);
+            });
+        });
+        return; // skip all other tests
+    }
+
     describe('cordova-plugin-secure-storage', function () {
 
         beforeEach(function () {


### PR DESCRIPTION
Currently, running an app containing this plugin on a device with Android 4.2 or below results in a native crash:

    FATAL EXCEPTION: pool-1-thread-2
    java.lang.NoClassDefFoundError: android.security.KeyPairGeneratorSpec$Builder
       at com.crypho.plugins.RSA.createKeyPair(RSA.java:40)
       at com.crypho.plugins.SecureStorage$1.run(SecureStorage.java:47)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
       at java.lang.Thread.run(Thread.java:856)

This pull request adds version detection to handle this more gracefully and invoke the error callback if the Android version is <4.4 (the minimum supported version as stated in README.md)