### PR TITLE
Add keyEncryptionRequired option for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ _init();
 
 ```
 
+If you don't want to force screen lock usage, it is possible to send additional option that disable key pair encryption when screen lock not used (more info about this requirements in [Android Security: The Forgetful Keystore](https://doridori.github.io/android-security-the-forgetful-keystore/) blog post): 
+
+```js
+new cordova.plugins.SecureStorage(
+  successCallback, errorCallback, appKey, {keyEncryptionRequired: false}
+);
+```
+
 ##### Android keystore deletion on security setting change
 
 Changing the lock screen type on Android erases the keystore (issues [61989](https://code.google.com/p/android/issues/detail?id=61989) and [210402](https://code.google.com/p/android/issues/detail?id=210402)). This is also described in the [Android Security: The Forgetful Keystore](https://doridori.github.io/android-security-the-forgetful-keystore/) blog post.

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -32,12 +32,12 @@ public class RSA {
 		}
 	}
 
-	public static void createKeyPair(Context ctx, String alias) throws Exception {
+	public static void createKeyPair(Context ctx, String alias, boolean encryptionRequired) throws Exception {
 		Calendar notBefore = Calendar.getInstance();
 		Calendar notAfter = Calendar.getInstance();
 		notAfter.add(Calendar.YEAR, 100);
 		String principalString = String.format("CN=%s, OU=%s", alias, ctx.getPackageName());
-		KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(ctx)
+		KeyPairGeneratorSpec.Builder builder = new KeyPairGeneratorSpec.Builder(ctx)
 			.setAlias(alias)
 			.setSubject(new X500Principal(principalString))
 			.setSerialNumber(BigInteger.ONE)
@@ -46,7 +46,10 @@ public class RSA {
 			.setEncryptionRequired()
 			.setKeySize(2048)
 			.setKeyType("RSA")
-			.build();
+		if (encryptionRequired) {
+			builder.setEncryptionRequired();
+		}
+		KeyPairGeneratorSpec spec = builder.build();
 		KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance("RSA", KEYSTORE_PROVIDER);
 		kpGenerator.initialize(spec);
 		kpGenerator.generateKeyPair();

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -43,7 +43,6 @@ public class RSA {
 			.setSerialNumber(BigInteger.ONE)
 			.setStartDate(notBefore.getTime())
 			.setEndDate(notAfter.getTime())
-			.setEncryptionRequired()
 			.setKeySize(2048)
 			.setKeyType("RSA")
 		if (encryptionRequired) {

--- a/www/securestorage.js
+++ b/www/securestorage.js
@@ -188,7 +188,7 @@ SecureStorageAndroid = function (success, error, service, options) {
             },
             error,
             'init',
-            [this.service]
+            [this.service, options.keyEncryptionRequired]
         );
     } catch (e) {
         error(e);
@@ -199,6 +199,7 @@ SecureStorageAndroid = function (success, error, service, options) {
 SecureStorageAndroid.prototype = {
     options: {
         native: true,
+        keyEncryptionRequired: true,
         migrateLocalStorage: false
     },
 


### PR DESCRIPTION
If set this option to `false`, there is no need to force enable screen lock. If screen lock is enabled, then will be used key pair encryption. If not - key pair encryption will be disabled and there is not necessary to fail plugin initialization.