### PR TITLE
fix(ios): Add support for reading __NSCFData key strings

### DIFF
--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -114,7 +114,11 @@
         if (accounts) {
             NSMutableArray *array = [NSMutableArray arrayWithCapacity:[accounts count]];
             for (id dict in accounts) {
-                [array addObject:[dict valueForKeyPath:@"acct"]];
+                if([NSStringFromClass([[dict valueForKeyPath:@"acct"] class]) isEqualToString:@"__NSCFData"]){
+                     [array addObject:[NSString stringWithUTF8String:[[dict valueForKeyPath:@"acct"] bytes]]];
+                }else{
+                    [array addObject:[dict valueForKeyPath:@"acct"]];
+                }
             }
 
             CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:array];


### PR DESCRIPTION
I'm creating a Cordova app to replace an existing native iOS app. When trying to read the existing keys from the previous app, the app crashed when trying to serialize the key strings because they had a different encoding (I think - the error message complained about the strings being of type "__NSCFData").

This commit fixes that issue for me, however I know nothing about native iOS development or Objective-C so I'm not sure my quick-fix is the optimal solution. I also don't know how to properly add tests for this change.

If I need to change anything to get this PR accepted please let me know.

Thanks for the great plugin!